### PR TITLE
Basic layout manager system for QAD-GUI.

### DIFF
--- a/src/main/java/de/longor/talecraft/client/gui/qad/QADComponent.java
+++ b/src/main/java/de/longor/talecraft/client/gui/qad/QADComponent.java
@@ -61,6 +61,8 @@ public abstract class QADComponent {
 	}
 
 	public void playPressSound(float pitch) {
+		// TODO: Extract the playing of sounds from this class into a QADSoundHandler class.
+		//       That should be done so in the future custom gui screens can have custom sound.
 		SoundHandler soundHandler = Minecraft.getMinecraft().getSoundHandler();
 		soundHandler.playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.ui_button_click, pitch));
 	}

--- a/src/main/java/de/longor/talecraft/client/gui/qad/QADComponentContainer.java
+++ b/src/main/java/de/longor/talecraft/client/gui/qad/QADComponentContainer.java
@@ -3,8 +3,36 @@ package de.longor.talecraft.client.gui.qad;
 import java.util.Collection;
 
 public interface QADComponentContainer {
+	public int getContainerWidth();
+	public int getContainerHeight();
+	
 	public <T extends QADComponent> T addComponent(T c);
 	public Collection<QADComponent> getComponents();
 	public QADComponent getComponentByName(String name);
 	public void removeAllComponents();
+	
+	/*
+		If getLayout returns NULL, this method is a NO-OP.
+		Else, the 'layout()'-method of the QADLayoutManager is invoked.
+		This method ignores the isLayoutDirty-method.
+	*/
+	public void forceRebuildLayout();
+	
+	/*
+		The layout should only be rebuilt if this flag returns true.
+		Note: The forceRebuildLayout-method does NOT check this flag.
+	*/
+	public boolean isLayoutDirty();
+	
+	/*
+		Returns the QADLayoutManager for this container.
+		If there is none, NULL will be returned.
+	*/
+	public QADLayoutManager getLayout();
+	
+	/*
+		Changes the layout manager to the given new layout manager.
+		This will immediately call the forceRebuildLayout-method.
+	*/
+	public void setLayout(QADLayoutManager newLayout);
 }

--- a/src/main/java/de/longor/talecraft/client/gui/qad/QADLayoutManager.txt
+++ b/src/main/java/de/longor/talecraft/client/gui/qad/QADLayoutManager.txt
@@ -1,0 +1,19 @@
+package de.longor.talecraft.client.gui.qad;
+
+import de.longor.talecraft.util.Vec2i;
+
+/*
+	(Abstract interface for declaring layout managers)
+	
+	A layout-manager is a class that lays out the component within a container,
+	according to coded in rules and parameters given to the layout-manager.
+*/
+interface QADLayoutManager {
+	
+	public void layout(
+		QADComponentContainer container,
+		List<QADComponent> components,
+		Vec2i newContainerSize,
+	);
+	
+}

--- a/src/main/java/de/longor/talecraft/client/gui/qad/QADPanel.java
+++ b/src/main/java/de/longor/talecraft/client/gui/qad/QADPanel.java
@@ -16,6 +16,8 @@ public class QADPanel extends QADRectangularComponent implements QADComponentCon
 	private int height;
 	private int backgroundColor;
 	private List<QADComponent> components;
+	private QADLayoutManager layout;
+	private boolean shouldRebuildLayout;
 
 	public boolean enabled;
 	public boolean visible;
@@ -24,6 +26,9 @@ public class QADPanel extends QADRectangularComponent implements QADComponentCon
 
 	public QADPanel() {
 		components = Lists.newArrayList();
+		layout = null;
+		shouldRebuildLayout = true;
+		
 		enabled = true;
 		visible = true;
 		ignoreOuterEvents = false;
@@ -94,6 +99,7 @@ public class QADPanel extends QADRectangularComponent implements QADComponentCon
 	@Override
 	public <T extends QADComponent> T addComponent(T c) {
 		components.add(c);
+		shouldRebuildLayout = true;
 		return c;
 	}
 
@@ -196,6 +202,11 @@ public class QADPanel extends QADRectangularComponent implements QADComponentCon
 	public void onTickUpdate() {
 		if(!enabled) return;
 
+		if(layout != null && isLayoutDirty()) {
+			layout.layout( this, components, new Vec2i() );
+			shouldRebuildLayout = false;
+		}
+
 		for(QADComponent component : components) {
 			component.onTickUpdate();
 		}
@@ -237,12 +248,35 @@ public class QADPanel extends QADRectangularComponent implements QADComponentCon
 	@Override
 	public void removeAllComponents() {
 		components.clear();
+		shouldRebuildLayout = true;
 	}
 
 	@Override
 	public QADEnumComponentClass getComponentClass() {
 		return QADEnumComponentClass.CONTAINER;
 	}
+	
+	public void forceRebuildLayout() {
+		if(layout != null) {
+			layout.layout( this, components, new Vec2i() );
+			shouldRebuildLayout = false;
+		}
+	}
+	
+	public boolean isLayoutDirty() {
+		return shouldRebuildLayout;
+	}
+	
+	public QADLayoutManager getLayout() {
+		return layout;
+	}
+	
+	public void setLayout(QADLayoutManager newLayout) {
+		layout = newLayout;
+		shouldRebuildLayout = true;
+	}
+
+
 
 	@Override
 	public boolean transferFocus() {

--- a/src/main/java/de/longor/talecraft/client/gui/qad/QADScrollPanel.java
+++ b/src/main/java/de/longor/talecraft/client/gui/qad/QADScrollPanel.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.google.common.collect.Lists;
 
 import de.longor.talecraft.client.gui.vcui.VCUIRenderer;
+import de.longor.talecraft.util.Vec2i;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 
@@ -16,7 +17,9 @@ public class QADScrollPanel extends QADRectangularComponent implements QADCompon
 	private int width;
 	private int height;
 	private List<QADComponent> components;
-
+	private QADLayoutManager layout;
+	private boolean shouldRebuildLayout;
+	
 	private int viewportPosition; // position of the view
 	private int viewportHeight; // height of the content
 
@@ -29,6 +32,9 @@ public class QADScrollPanel extends QADRectangularComponent implements QADCompon
 
 	public QADScrollPanel() {
 		components = Lists.newArrayList();
+		layout = null;
+		shouldRebuildLayout = true;
+		
 		enabled = true;
 		visible = true;
 
@@ -111,6 +117,7 @@ public class QADScrollPanel extends QADRectangularComponent implements QADCompon
 	@Override
 	public <T extends QADComponent> T addComponent(T component) {
 		components.add(component);
+		shouldRebuildLayout = true;
 		return component;
 	}
 
@@ -273,8 +280,19 @@ public class QADScrollPanel extends QADRectangularComponent implements QADCompon
 	public void onTickUpdate() {
 		if(!enabled) return;
 
-		if(height > viewportHeight) {
+		if(isLayoutDirty()) {
+			relayout();
+		}
+
+		if(height >= viewportHeight) {
+			// (content height is smaller than view height)
 			viewportPosition = 0;
+		} else {
+			// (content height is larger than view height)
+			// slowly scroll up!
+			if(viewportPosition + height > viewportHeight) {
+				viewportPosition -= 1;
+			}
 		}
 
 		for(QADComponent component : components) {
@@ -318,11 +336,38 @@ public class QADScrollPanel extends QADRectangularComponent implements QADCompon
 	@Override
 	public void removeAllComponents() {
 		components.clear();
+		shouldRebuildLayout = true;
 	}
 
 	@Override
 	public QADEnumComponentClass getComponentClass() {
 		return QADEnumComponentClass.CONTAINER;
+	}
+	
+	private void relayout() {
+		if(layout != null) {
+			Vec2i newSize = new Vec2i();
+			layout.layout( this, components, newSize);
+			viewportHeight = newSize.y;
+			shouldRebuildLayout = false;
+		}
+	}
+	
+	public void forceRebuildLayout() {
+		relayout();
+	}
+	
+	public boolean isLayoutDirty() {
+		return shouldRebuildLayout;
+	}
+	
+	public QADLayoutManager getLayout() {
+		return layout;
+	}
+	
+	public void setLayout(QADLayoutManager newLayout) {
+		layout = newLayout;
+		shouldRebuildLayout = true;
 	}
 
 	@Override

--- a/src/main/java/de/longor/talecraft/client/gui/qad/layout/QADListLayout.java
+++ b/src/main/java/de/longor/talecraft/client/gui/qad/layout/QADListLayout.java
@@ -1,0 +1,87 @@
+package de.longor.talecraft.client.gui.qad.layout;
+
+import de.longor.talecraft.client.gui.qad.QADLayoutManager;
+import de.longor.talecraft.util.Vec2i;
+
+/*
+	QADLayoutManager that arranges components in a list.
+*/
+class QADListLayout implements QADLayoutManager {
+	private int rowHeight;
+	
+	/*
+		No row-height given, using '20'.
+	*/
+	public QADListLayout() {
+		this.rowHeight = 20;
+	}
+	
+	public QADListLayout(int rowHeight) {
+		this.rowHeight = rowHeight;
+	}
+	
+	@Override
+	public void layout(
+		QADComponentContainer container,
+		List<QADComponent> components,
+		Vec2i newContainerSize
+	) {
+		
+		// TODO: make this a parameter
+		int vgap = 2;
+		int hgap = 1;
+		
+		int width = container.getContainerWidth() - (hgap*2);
+		int height = rowHeight;
+		
+		
+		// How much Y gets increased with every component.
+		int yIncrement = vgap + height;
+		
+		// Current Y position to place a component at.
+		int currentY = 0 + vgap;
+		for(QADComponent component : components) {
+			int yIncrementAlt = 0;
+			
+			// Is this a rectangular component/a component with size?
+			if(component instanceof QADRectangularComponent) {
+				QADRectangularComponent rectComp = component;
+				
+				int maxW = Math.max(width , rectComp.getWidth ());
+				int maxH = Math.max(height, rectComp.getHeight());
+				yIncrementAlt = maxH + vgap;
+				
+				if( rectComp.canResize() ) {
+					// We can resize the component;
+					// so we do that!
+					component.setX(hgap);
+					component.setY(currentY);
+					rectComp.setSize(maxW, maxH);
+				} else {
+					// can't resize, center it in the row.
+					// XXX: Add feature to let row height vary per component?
+					
+					rectComp.setX( (width / 2) - (rectComp.getWidth ()/2) + hgap);
+					rectComp.setY( (maxH  / 2) - (rectComp.getHeight()/2) + currentY);
+				}
+			} else {
+				// Component has no size; place it and hope it fits.
+				component.setX(hgap);
+				component.setY(currentY);
+			}
+			
+			// In the small case that the layout of a sub-container got dirty,
+			// go and rebuild its layout (if needed!).
+			if(component instanceof QADContainerComponent) {
+				if(((QADContainerComponent)component).isLayoutDirty())
+					((QADContainerComponent)component).forceRebuildLayout();
+			}
+			
+			currentY += Math.max(yIncrement, yIncrementAlt);
+		}
+		
+		// Set new container size.
+		newContainerSize.y = currentY + vgap;
+	}
+	
+}


### PR DESCRIPTION
This pull request implements basic layout management into the QAD-GUI system.

Included in this commit is a basic "list" layout manager, to use it call `setLayout(new QADListLayout())` on a `QADContainerComponent`, the list layout-manager will handle the rest.

I suggest merging it in another (new) branch and testing it for a bit before merging it into the actual master branch, because I have NOT tested if this code runs or even compiles (didn't have time).

I hope I haven't forgot anything.