### PR TITLE
Fix  /tcc_vismode command

### DIFF
--- a/src/java/de/longor/talecraft/client/commands/VisualizationModeCommand.java
+++ b/src/java/de/longor/talecraft/client/commands/VisualizationModeCommand.java
@@ -25,7 +25,7 @@ public final class VisualizationModeCommand extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-		final VisualMode mode = VisualMode.valueOf(args[0].toUpperCase());
+		final VisualMode mode = VisualMode.valueOf(args[0]);
 
 		ClientProxy.shedule(new Runnable() {
 			@Override


### PR DESCRIPTION
The command didn't work because the enum values aren't uppercase.